### PR TITLE
Issue / Nuxt 3 / Reload Causes Resource Not Found

### DIFF
--- a/.theme/app.vue
+++ b/.theme/app.vue
@@ -1,5 +1,16 @@
 <template>
-  <div>
-    <NuxtPage />
-  </div>
+  <!-- key is added to avoid multiple rendering after navigation -->
+  <NuxtPage :key="`nuxt-page:${$route.path}`" />
 </template>
+<script setup>
+import { useRoute, navigateTo, onMounted } from "#imports";
+
+const route = useRoute();
+
+onMounted(() => {
+  if(route.path?.endsWith("/")) {
+    // replace prevents browser to record this navigation in its history
+    navigateTo(route.path.slice(0, -1), { replace: true });
+  }
+});
+</script>

--- a/.theme/app.vue
+++ b/.theme/app.vue
@@ -1,16 +1,23 @@
 <template>
-  <!-- key is added to avoid multiple rendering after navigation -->
-  <NuxtPage :key="`nuxt-page:${$route.path}`" />
+  <div>
+    <!-- key is required to overcome hydration and multiple render issues -->
+    <NuxtPage :key="$route.path" />
+  </div>
 </template>
 <script setup>
 import { useRoute, navigateTo, onMounted } from "#imports";
 
 const route = useRoute();
 
-onMounted(() => {
-  if(route.path?.endsWith("/")) {
+onMounted(async () => {
+  if(route.path.endsWith("/")) {
+    const { path, query, hash } = route;
+    const nextPath = path.replace(/\/+$/, "") || "/";
+    const nextRoute = { path: nextPath, query, hash };
+
+    // works only if `router.options.strict` is enabled in `nuxt.config.ts`
     // replace prevents browser to record this navigation in its history
-    navigateTo(route.path.slice(0, -1), { replace: true });
+    await navigateTo(nextRoute, { replace: true });
   }
 });
 </script>

--- a/.theme/nuxt.config.ts
+++ b/.theme/nuxt.config.ts
@@ -48,6 +48,11 @@ export default defineNuxtConfig({
       },
     },
   },
+  router: {
+    options: {
+      strict: true
+    }
+  },
   components: {
     dirs: [
       { global: true , path: "~/components/Prose" },

--- a/README.md
+++ b/README.md
@@ -113,12 +113,21 @@ Demo is at [/demo/content-query](/demo/content-query)
 
 Nuxt generates an `index.html` file under each route and this causes some
 static site hosting services, such as GitHub Pages, to add a trailing slash to
-urls. When this happens that page fails to load resources with a relative path.
-To workaround this we've added a client side script that checks if `route.path`
-has a trailing slash. We know that this is not the best solution, but for now
-this is the workaround we use.
+urls. When this happens that page fails to load resources with a relative path
+because a trailing slash would indicate another directory in a path.
 
-You can see this work around in `.theme/app.vue` file.
+To workaround this, we've added a script that checks if `route.path` has a
+trailing slash upon mounting. We know that this is not the best solution, but
+for now this is the workaround we use.
+
+> :warning:
+>
+> For this solution to work correctly, you need to enable
+> `router.options.strict` in `.theme/nuxt.config.ts` so that a path with a
+> trailing slash is not treated as same as a path without a trailing slash.
+> Otherwise `navigateTo` does not redirect and throws an error.
+
+Solution is in `.theme/app.vue`.
 
 ## Public Assets
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ reduce the crowd in the script.
 
 Demo is at [/demo/content-query](/demo/content-query)
 
+### Trailing Slash Problem Workaround
+
+Nuxt generates an `index.html` file under each route and this causes some
+static site hosting services, such as GitHub Pages, to add a trailing slash to
+urls. When this happens that page fails to load resources with a relative path.
+To workaround this we've added a client side script that checks if `route.path`
+has a trailing slash. We know that this is not the best solution, but for now
+this is the workaround we use.
+
+You can see this work around in `.theme/app.vue` file.
+
 ## Public Assets
 
 To serve static assets in a theme like `.css` or `.png` files simply put any

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to](other-file.md)` format as demonstrated below;
 
 To include an image in markdown, place image files in a folder named `-images`
 at the same path as that markdown file. For example; if you have a file
-`/demo/image-in-content.md`, place its images in `/demo/-images`.
+`/content/images.md`, place its images in `/content/-images`.
 
 Demo is at [Content / Images](content/images.md)
 


### PR DESCRIPTION
Reload in index pages causes browser to put a `/` at the end of the path which causes browser to treat this path as a folder and causes relative resources not to load.

## Tasks

- [x] Investigate this issue and try to find a workaround
- [x] apply and document the workaround
- [x] further investigation for `/demo/...` pages